### PR TITLE
1. Remove MultiAgentSyncReplayOptimizer, and make before_learn_on_bat…

### DIFF
--- a/python/ray/rllib/agents/maddpg/README.md
+++ b/python/ray/rllib/agents/maddpg/README.md
@@ -6,6 +6,8 @@
         - `simple`, `simple_adversary`, `simple_crypto`, `simple_push`, `simple_speaker_listener`, `simple_spread`, `simple_tag`
             - RLlib MADDPG shows the similar performance as OpenAI MADDPG on 7 scenarios except `simple_crypto`. 
     - Hyperparameters were set to follow the original hyperparameter setting in [OpenAI/MADDPG](https://github.com/openai/maddpg).
+    
+- Empirically, it was shown that running without `lz4` shows much faster performance.
 
 ## References
 - [OpenAI/MADDPG](https://github.com/openai/maddpg)

--- a/python/ray/rllib/optimizers/__init__.py
+++ b/python/ray/rllib/optimizers/__init__.py
@@ -8,7 +8,6 @@ from ray.rllib.optimizers.sync_replay_optimizer import SyncReplayOptimizer
 from ray.rllib.optimizers.sync_batch_replay_optimizer import \
     SyncBatchReplayOptimizer
 from ray.rllib.optimizers.multi_gpu_optimizer import LocalMultiGPUOptimizer
-from ray.rllib.optimizers.multiagent_sync_replay_optimizer import MultiAgentSyncReplayOptimizer
 
 __all__ = [
     "PolicyOptimizer",
@@ -19,5 +18,4 @@ __all__ = [
     "SyncReplayOptimizer",
     "LocalMultiGPUOptimizer",
     "SyncBatchReplayOptimizer",
-    "MultiAgentSyncReplayOptimizer",
 ]


### PR DESCRIPTION
…ch as input for SyncReplayOptimizer.

2. Add `synchronize_sampling` argument to `SyncReplayOptimizer.__init__`, which is necessary for centralized critic training.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?



## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
